### PR TITLE
fix: improving internal protocol - pass messageID and parentMessageID

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -48,6 +48,11 @@ type Message struct {
 	Extra     map[string][]interface{}
 }
 
+type OriginalMessageIds struct {
+	ID       string `json:"id"`
+	ParentID string `json:"parent_id"`
+}
+
 func (m Message) ParentNotFound() bool {
 	return m.ParentID == ParentIDNotFound
 }

--- a/bridge/status/status.go
+++ b/bridge/status/status.go
@@ -228,6 +228,19 @@ func (b *Bstatus) toStatusMsg(msg config.Message) *common.Message {
 	message := common.NewMessage()
 	message.ChatId = msg.Channel
 	message.ContentType = protobuf.ChatMessage_BRIDGE_MESSAGE
+
+	var originalID, originalParentID string
+	if msg.Extra != nil {
+		originalMessageIdsList := msg.Extra["OriginalMessageIds"]
+		if len(originalMessageIdsList) == 1 {
+			originalMessageIds, ok := originalMessageIdsList[0].(config.OriginalMessageIds)
+			if ok {
+				originalID = originalMessageIds.ID
+				originalParentID = originalMessageIds.ParentID
+			}
+		}
+	}
+
 	message.Payload = &protobuf.ChatMessage_BridgeMessage{
 		BridgeMessage: &protobuf.BridgeMessage{
 			BridgeName:      msg.Protocol,
@@ -235,8 +248,8 @@ func (b *Bstatus) toStatusMsg(msg config.Message) *common.Message {
 			UserAvatar:      msg.Avatar,
 			UserID:          msg.UserID,
 			Content:         msg.Text,
-			MessageID:       msg.ID,
-			ParentMessageID: msg.ParentID,
+			MessageID:       originalID,
+			ParentMessageID: originalParentID,
 		},
 	}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -464,6 +464,16 @@ func (gw *Gateway) SendMessage(
 	msg.Avatar = gw.modifyAvatar(rmsg, dest)
 	msg.Username = gw.modifyUsername(rmsg, dest)
 
+	// ID and ParentID are for some reason cleared by getDestMsgID
+	// We need them to send to Status
+	if msg.Extra == nil {
+		msg.Extra = make(map[string][]interface{})
+	}
+	msg.Extra["OriginalMessageIds"] = []interface{}{config.OriginalMessageIds{
+		ID:       msg.ID,
+		ParentID: msg.ParentID,
+	}}
+
 	// exclude file delete event as the msg ID here is the native file ID that needs to be deleted
 	if msg.Event != config.EventFileDelete {
 		msg.ID = gw.getDestMsgID(rmsg.Protocol+" "+rmsg.ID, dest, channel)


### PR DESCRIPTION
messageID and parentMessageID are cleared in the gateway (not sure why).
We need this info in Status to handle replies.
I did not want to change the protocol logic, so I added this info in metadata field.

Issue [#13258](https://github.com/status-im/status-desktop/issues/13258)