### PR TITLE
fix: replace newline from message with br to display newlines correctly

### DIFF
--- a/bridge/status/status.go
+++ b/bridge/status/status.go
@@ -223,6 +223,10 @@ func (b *Bstatus) propagateMessage(msg *common.Message) {
 	}
 }
 
+func (b *Bstatus) nl2br(input string) string {
+	return strings.Replace(input, "\n", "<br/>", -1)
+}
+
 // Converts a bridge message into a Status message
 func (b *Bstatus) toStatusMsg(msg config.Message) *common.Message {
 	message := common.NewMessage()
@@ -282,6 +286,8 @@ func (b *Bstatus) Send(msg config.Message) (string, error) {
 	if !b.connected() {
 		return "", fmt.Errorf("bridge %s not connected, dropping message %#v to bridge", b.Account, msg)
 	}
+
+	msg.Text = b.nl2br(msg.Text)
 
 	b.Log.Debugf("=> Sending message %#v", msg)
 


### PR DESCRIPTION
Replace new lines with br tag in bridge, before sending to Status.

Fix [#15291](https://github.com/status-im/status-desktop/issues/15291)