### PR TITLE
fix(replies): fix replies from Status and to Status messages

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -337,7 +337,7 @@ func (b *Bdiscord) handleEventBotUser(msg *config.Message, channelID string) (st
 	}
 
 	m := discordgo.MessageSend{
-		Content:         msg.Username + msg.Text,
+		Content:         msg.Username + ": " + msg.Text,
 		AllowedMentions: b.getAllowedMentions(),
 	}
 

--- a/status.toml
+++ b/status.toml
@@ -12,6 +12,7 @@
     RemoteNickFormat="{NICK}"
     DataDir="path to status data dir"
     NodeConfigFile="path to json with node config and fleets"
+    PreserveThreading=true
 
 [discord]
     [discord.mydiscord]
@@ -19,6 +20,7 @@
     Server=""
     AutoWebhooks=true
     RemoteNickFormat="{NICK}"
+    PreserveThreading=true
 
 [[gateway]]
 name="gateway3"


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/16323

There were multiple problems.

1. The ParentID was not set correctly when a message was sent from Status
2. We didn't send back the ID of messages that we sent, so the gateway couldn't associate the new messages to the old ones
3. Missing param in the toml config `PreserveThreading`
4. Discord messages are weirdly formatted when a reply is send. It cannot use webhooks, so we need to pass the username directly in the message (it's ugly, but it works)

Finally, there was an issue on the status-go side. We tried to use the discord message ID to find the replies, but the bridge already converts it to the right ID, so we could just use it directly

How it looks in Status:
![image](https://github.com/user-attachments/assets/914520aa-b779-441f-a2cc-87592792a842)


How it looks in Discord:
![image](https://github.com/user-attachments/assets/54f5a0b6-aaf4-4f34-8594-8291f80813f0)

They all work now. The only sad thing is replies from Status look a bit ugly in Discord, but that's a limitation in the Discord API I think. 
