### PR TITLE
feat: add Signal protocol bridge

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -205,6 +205,7 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude-dirs:
     - bridge/status
+    - bridge/signal
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ ENV CXX=clang++
 
 RUN go build -ldflags=-checklinkname=0 -o /bin/matterbridge
 
-FROM gcr.io/distroless/static-debian11
-
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /bin/matterbridge /bin/matterbridge
 
 ENTRYPOINT ["/bin/matterbridge"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,15 @@ pipeline {
   }
 
   stages {
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [[name: params.GIT_REF]],
+          userRemoteConfigs: scm.userRemoteConfigs
+        ])
+      }
+    }
     stage('Build') {
       steps { script {
         env.IMAGE_TAG = params.IMAGE_TAG ?: env.GIT_COMMIT.take(8)

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -140,6 +140,7 @@ type Protocol struct {
 	NicksPerRow            int        // mattermost, slack
 	NoHomeServerSuffix     bool       // matrix
 	NodeConfigFile         string     // status
+	Number                 string     // signal
 	NoSendJoinPart         bool       // all protocols
 	NoTLS                  bool       // mattermost, xmpp
 	Password               string     // IRC,mattermost,XMPP,matrix
@@ -156,6 +157,7 @@ type Protocol struct {
 	RemoteNickFormat       string     // all protocols
 	RunCommands            []string   // IRC
 	Server                 string     // IRC,mattermost,XMPP,discord,matrix
+	SignalAPIURL           string     // signal
 	SessionFile            string     // msteams,whatsapp
 	ShowJoinPart           bool       // all protocols
 	ShowTopicChange        bool       // slack
@@ -230,6 +232,7 @@ type BridgeValues struct {
 	Slack              map[string]Protocol
 	SlackLegacy        map[string]Protocol
 	Status             map[string]Protocol
+	Signal             map[string]Protocol
 	Steam              map[string]Protocol
 	Gitter             map[string]Protocol
 	XMPP               map[string]Protocol

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -16,6 +17,8 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/gorilla/websocket"
 )
+
+const maxAttachmentSize = 20 * 1024 * 1024 // 20MB
 
 type Bsignal struct {
 	*bridge.Config
@@ -53,8 +56,8 @@ type signalDataMessage struct {
 }
 
 type signalEditMessage struct {
-	TargetSentTimestamp int64              `json:"targetSentTimestamp"`
-	DataMessage         signalDataMessage  `json:"dataMessage"`
+	TargetSentTimestamp int64             `json:"targetSentTimestamp"`
+	DataMessage         signalDataMessage `json:"dataMessage"`
 }
 
 type signalGroupInfo struct {
@@ -120,7 +123,6 @@ func (b *Bsignal) Connect() error {
 		return fmt.Errorf("Number not configured")
 	}
 
-	// Derive WebSocket URL from HTTP URL
 	b.wsURL = strings.Replace(b.apiURL, "http://", "ws://", 1)
 	b.wsURL = strings.Replace(b.wsURL, "https://", "wss://", 1)
 
@@ -136,7 +138,6 @@ func (b *Bsignal) Connect() error {
 		return fmt.Errorf("signal-cli API returned status %d", resp.StatusCode)
 	}
 
-	// Build group ID mapping: receive returns internal_id, config and send use id
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read groups response: %w", err)
@@ -174,22 +175,26 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 		return "", nil
 	}
 
-	b.Log.Debugf("=> Sending message to Signal group %s: %s", msg.Channel, msg.Text)
+	// Prepend username to message text since Signal has no webhook/impersonation
+	text := msg.Text
+	if msg.Username != "" {
+		text = msg.Username + msg.Text
+	}
+
+	b.Log.Debugf("=> Sending message to Signal group %s: %s", msg.Channel, text)
 
 	req := signalSendRequest{
-		Message:    msg.Text,
+		Message:    text,
 		Number:     b.number,
 		Recipients: []string{"group." + msg.Channel},
 	}
 
-	// Handle reply/quote from other bridges
 	if msg.ParentID != "" {
 		if ts, err := strconv.ParseInt(msg.ParentID, 10, 64); err == nil {
 			req.QuoteTimestamp = &ts
 		}
 	}
 
-	// Handle attachments from other bridges (e.g. Discord CDN URLs)
 	if files, ok := msg.Extra["file"]; ok {
 		for _, f := range files {
 			fi, ok := f.(config.FileInfo)
@@ -205,12 +210,12 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 					b.Log.Errorf("Failed to download attachment from %s: %s", fi.URL, err)
 					continue
 				}
-				data, _ = io.ReadAll(resp.Body)
+				data, _ = io.ReadAll(io.LimitReader(resp.Body, maxAttachmentSize))
 				resp.Body.Close()
 			}
 			if len(data) > 0 {
-				mime := mimeFromFilename(fi.Name)
-				b64 := fmt.Sprintf("data:%s;base64,%s", mime, base64.StdEncoding.EncodeToString(data))
+				mt := mimeFromFilename(fi.Name)
+				b64 := fmt.Sprintf("data:%s;base64,%s", mt, base64.StdEncoding.EncodeToString(data))
 				req.Base64Attachments = append(req.Base64Attachments, b64)
 			}
 		}
@@ -236,7 +241,6 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 		return "", fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	// Return signal timestamp as message ID for cross-protocol tracking
 	var sendResp signalSendResponse
 	if err := json.Unmarshal(respBody, &sendResp); err == nil && sendResp.Timestamp != "" {
 		return sendResp.Timestamp, nil
@@ -261,7 +265,7 @@ func (b *Bsignal) receiveLoop() {
 
 func (b *Bsignal) receiveMessages() {
 	wsURL := fmt.Sprintf("%s/v1/receive/%s", b.wsURL, b.number)
-	b.Log.Infof("Opening WebSocket connection to %s", wsURL)
+	b.Log.Debugf("Opening WebSocket connection to %s", wsURL)
 
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
@@ -300,7 +304,6 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		return
 	}
 
-	// Handle edit message
 	if msg.Envelope.EditMessage != nil {
 		b.handleEditMessage(msg)
 		return
@@ -321,7 +324,6 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		return
 	}
 
-	// Handle remote delete
 	if dm.RemoteDelete != nil {
 		b.Remote <- config.Message{
 			Event:    config.EventMsgDelete,
@@ -333,7 +335,6 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		return
 	}
 
-	// Skip messages with no text and no attachments
 	if dm.Message == "" && len(dm.Attachments) == 0 {
 		return
 	}
@@ -353,12 +354,10 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		Timestamp: time.UnixMilli(dm.Timestamp),
 	}
 
-	// Handle quote/reply
 	if dm.Quote != nil {
 		rmsg.ParentID = strconv.FormatInt(dm.Quote.ID, 10)
 	}
 
-	// Handle attachments
 	for _, att := range dm.Attachments {
 		data, err := b.downloadAttachment(att.ID)
 		if err != nil {
@@ -377,7 +376,6 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		rmsg.Extra["file"] = append(rmsg.Extra["file"], fi)
 	}
 
-	// When attachments carry the caption, clear text to avoid duplication
 	if len(dm.Attachments) > 0 && dm.Message != "" {
 		rmsg.Text = ""
 	}
@@ -408,7 +406,6 @@ func (b *Bsignal) handleEditMessage(msg signalMessage) {
 		username = msg.Envelope.Source
 	}
 
-	// Use targetSentTimestamp as ID so gateway maps it to the original Discord message
 	b.Remote <- config.Message{
 		Username:  username,
 		Text:      dm.Message,
@@ -431,7 +428,7 @@ func (b *Bsignal) downloadAttachment(id string) (*[]byte, error) {
 		return nil, fmt.Errorf("attachment endpoint returned %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxAttachmentSize))
 	if err != nil {
 		return nil, fmt.Errorf("read failed: %w", err)
 	}
@@ -439,17 +436,9 @@ func (b *Bsignal) downloadAttachment(id string) (*[]byte, error) {
 }
 
 func mimeFromFilename(name string) string {
-	ext := strings.ToLower(filepath.Ext(name))
-	types := map[string]string{
-		".jpg": "image/jpeg", ".jpeg": "image/jpeg",
-		".png": "image/png", ".gif": "image/gif",
-		".webp": "image/webp", ".svg": "image/svg+xml",
-		".mp4": "video/mp4", ".webm": "video/webm",
-		".mp3": "audio/mpeg", ".ogg": "audio/ogg",
-		".pdf": "application/pdf",
+	t := mime.TypeByExtension(filepath.Ext(name))
+	if t == "" {
+		return "application/octet-stream"
 	}
-	if mime, ok := types[ext]; ok {
-		return mime
-	}
-	return "application/octet-stream"
+	return t
 }

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -113,7 +113,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	return &Bsignal{
 		Config:    cfg,
 		fetchDone: make(chan bool),
-		client:    &http.Client{Timeout: 60 * time.Second},
+		client:    &http.Client{Timeout: 10 * time.Second},
 		groupMap:  make(map[string]string),
 	}
 }
@@ -210,50 +210,22 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 		}
 	}
 
+	// Handle attachments from other bridges
 	if files, ok := msg.Extra["file"]; ok {
 		for _, f := range files {
 			fi, ok := f.(config.FileInfo)
 			if !ok {
 				continue
 			}
-			var data []byte
-			if fi.Data != nil {
-				data = *fi.Data
-			} else if fi.URL != "" {
-				resp, err := b.client.Get(fi.URL)
-				if err != nil {
-					b.Log.Errorf("Failed to download attachment from %s: %s", fi.URL, err)
-					continue
-				}
-				data, _ = io.ReadAll(io.LimitReader(resp.Body, maxAttachmentSize))
-				resp.Body.Close()
-			}
-			if len(data) > 0 {
-				mt := mimeFromFilename(fi.Name)
-				b64 := fmt.Sprintf("data:%s;base64,%s", mt, base64.StdEncoding.EncodeToString(data))
-				req.Base64Attachments = append(req.Base64Attachments, b64)
+			if att := b.prepareAttachment(fi); att != "" {
+				req.Base64Attachments = append(req.Base64Attachments, att)
 			}
 		}
 	}
 
-	data, err := json.Marshal(req)
+	respBody, err := b.apiRequest(http.MethodPost, fmt.Sprintf("%s/v2/send", b.apiURL), req)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal message: %w", err)
-	}
-
-	resp, err := b.client.Post(
-		fmt.Sprintf("%s/v2/send", b.apiURL),
-		"application/json",
-		bytes.NewBuffer(data),
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to send message: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(respBody))
+		return "", err
 	}
 
 	var sendResp signalSendResponse
@@ -283,33 +255,60 @@ func (b *Bsignal) handleSendDelete(msg config.Message) (string, error) {
 		Timestamp: ts,
 	}
 
-	data, err := json.Marshal(delReq)
+	_, err = b.apiRequest(http.MethodDelete, fmt.Sprintf("%s/v1/remote-delete/%s", b.apiURL, b.number), delReq)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal delete request: %w", err)
+		return "", err
 	}
 
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		fmt.Sprintf("%s/v1/remote-delete/%s", b.apiURL, b.number),
-		bytes.NewBuffer(data),
-	)
+	return "", nil
+}
+
+// prepareAttachment converts a config.FileInfo into a base64-encoded data URI for signal-cli.
+func (b *Bsignal) prepareAttachment(fi config.FileInfo) string {
+	var data []byte
+	if fi.Data != nil {
+		data = *fi.Data
+	} else if fi.URL != "" {
+		resp, err := b.client.Get(fi.URL)
+		if err != nil {
+			b.Log.Errorf("Failed to download attachment from %s: %s", fi.URL, err)
+			return ""
+		}
+		data, _ = io.ReadAll(io.LimitReader(resp.Body, maxAttachmentSize))
+		resp.Body.Close()
+	}
+	if len(data) == 0 {
+		return ""
+	}
+	mt := mimeFromFilename(fi.Name)
+	return fmt.Sprintf("data:%s;base64,%s", mt, base64.StdEncoding.EncodeToString(data))
+}
+
+// apiRequest sends a JSON request to the signal-cli REST API and returns the response body.
+func (b *Bsignal) apiRequest(method, url string, payload interface{}) ([]byte, error) {
+	data, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("failed to create delete request: %w", err)
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := b.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to send delete request: %w", err)
+		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("signal-cli delete returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	return "", nil
+	return respBody, nil
 }
 
 // WebSocket receive loop with automatic reconnection

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -1,0 +1,251 @@
+package signal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/42wim/matterbridge/bridge"
+	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/gorilla/websocket"
+)
+
+type Bsignal struct {
+	*bridge.Config
+
+	apiURL    string
+	wsURL     string
+	number    string
+	fetchDone chan bool
+	client    *http.Client
+	// maps signal-cli internal_id (from receive) -> id (used in gateway config and send)
+	groupMap map[string]string
+}
+
+type signalMessage struct {
+	Envelope signalEnvelope `json:"envelope"`
+}
+
+type signalEnvelope struct {
+	Source      string             `json:"source"`
+	SourceName  string             `json:"sourceName"`
+	Timestamp   int64              `json:"timestamp"`
+	DataMessage *signalDataMessage `json:"dataMessage"`
+}
+
+type signalDataMessage struct {
+	Message   string           `json:"message"`
+	Timestamp int64            `json:"timestamp"`
+	GroupInfo *signalGroupInfo `json:"groupInfo"`
+}
+
+type signalGroupInfo struct {
+	GroupID string `json:"groupId"`
+	Type    string `json:"type"`
+}
+
+type signalSendRequest struct {
+	Message    string   `json:"message"`
+	Number     string   `json:"number"`
+	Recipients []string `json:"recipients"`
+}
+
+type signalGroup struct {
+	ID         string `json:"id"`
+	InternalID string `json:"internal_id"`
+}
+
+func New(cfg *bridge.Config) bridge.Bridger {
+	return &Bsignal{
+		Config:    cfg,
+		fetchDone: make(chan bool),
+		client:    &http.Client{Timeout: 30 * time.Second},
+		groupMap:  make(map[string]string),
+	}
+}
+
+func (b *Bsignal) Connect() error {
+	b.apiURL = b.GetString("SignalAPIURL")
+	if b.apiURL == "" {
+		return fmt.Errorf("SignalAPIURL not configured")
+	}
+
+	b.number = b.GetString("Number")
+	if b.number == "" {
+		return fmt.Errorf("Number not configured")
+	}
+
+	// Derive WebSocket URL from HTTP URL
+	b.wsURL = strings.Replace(b.apiURL, "http://", "ws://", 1)
+	b.wsURL = strings.Replace(b.wsURL, "https://", "wss://", 1)
+
+	b.Log.Infof("Connecting to signal-cli REST API at %s for number %s", b.apiURL, b.number)
+
+	resp, err := b.client.Get(fmt.Sprintf("%s/v1/groups/%s", b.apiURL, b.number))
+	if err != nil {
+		return fmt.Errorf("failed to connect to signal-cli API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("signal-cli API returned status %d", resp.StatusCode)
+	}
+
+	// Build group ID mapping: receive endpoint returns internal_id,
+	// but gateway config and send endpoint use id
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read groups response: %w", err)
+	}
+
+	var groups []signalGroup
+	if err := json.Unmarshal(body, &groups); err != nil {
+		return fmt.Errorf("failed to parse groups: %w", err)
+	}
+
+	for _, g := range groups {
+		id := strings.TrimPrefix(g.ID, "group.")
+		b.groupMap[g.InternalID] = id
+		b.Log.Debugf("Group mapping: %s -> %s", g.InternalID, id)
+	}
+
+	b.Log.Info("Connected to signal-cli REST API")
+	go b.receiveLoop()
+
+	return nil
+}
+
+func (b *Bsignal) Disconnect() error {
+	close(b.fetchDone)
+	return nil
+}
+
+func (b *Bsignal) JoinChannel(channel config.ChannelInfo) error {
+	b.Log.Infof("Joining Signal group %s", channel.Name)
+	return nil
+}
+
+func (b *Bsignal) Send(msg config.Message) (string, error) {
+	if msg.Event == config.EventMsgDelete {
+		return "", nil
+	}
+
+	b.Log.Debugf("=> Sending message to Signal group %s: %s", msg.Channel, msg.Text)
+
+	req := signalSendRequest{
+		Message:    msg.Text,
+		Number:     b.number,
+		Recipients: []string{"group." + msg.Channel},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal message: %w", err)
+	}
+
+	resp, err := b.client.Post(
+		fmt.Sprintf("%s/v2/send", b.apiURL),
+		"application/json",
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to send message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return "", nil
+}
+
+func (b *Bsignal) receiveLoop() {
+	for {
+		select {
+		case <-b.fetchDone:
+			return
+		default:
+			b.receiveMessages()
+			// Backoff before reconnecting
+			time.Sleep(3 * time.Second)
+		}
+	}
+}
+
+func (b *Bsignal) receiveMessages() {
+	wsURL := fmt.Sprintf("%s/v1/receive/%s", b.wsURL, b.number)
+	b.Log.Infof("Opening WebSocket connection to %s", wsURL)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		b.Log.Errorf("WebSocket connection failed: %s", err)
+		return
+	}
+	defer conn.Close()
+
+	b.Log.Info("WebSocket connected, listening for messages")
+
+	for {
+		select {
+		case <-b.fetchDone:
+			return
+		default:
+		}
+
+		_, rawMsg, err := conn.ReadMessage()
+		if err != nil {
+			b.Log.Errorf("WebSocket read error: %s", err)
+			return // Will reconnect via receiveLoop
+		}
+
+		var msg signalMessage
+		if err := json.Unmarshal(rawMsg, &msg); err != nil {
+			b.Log.Debugf("Failed to parse WebSocket message: %s", err)
+			continue
+		}
+
+		b.handleMessage(msg)
+	}
+}
+
+func (b *Bsignal) handleMessage(msg signalMessage) {
+	dm := msg.Envelope.DataMessage
+	if dm == nil || dm.Message == "" {
+		return
+	}
+
+	if dm.GroupInfo == nil {
+		return
+	}
+
+	if msg.Envelope.Source == b.number {
+		return
+	}
+
+	// Map internal_id from receive to id used in gateway config
+	channel, ok := b.groupMap[dm.GroupInfo.GroupID]
+	if !ok {
+		b.Log.Warnf("Unknown group internal_id: %s", dm.GroupInfo.GroupID)
+		return
+	}
+
+	username := msg.Envelope.SourceName
+	if username == "" {
+		username = msg.Envelope.Source
+	}
+
+	b.Remote <- config.Message{
+		Username:  username,
+		Text:      dm.Message,
+		Channel:   channel,
+		Account:   b.Account,
+		Protocol:  "signal",
+		Timestamp: time.UnixMilli(dm.Timestamp),
+	}
+}

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -92,10 +92,16 @@ type signalSendRequest struct {
 	QuoteTimestamp    *int64   `json:"quote_timestamp,omitempty"`
 	QuoteAuthor       string   `json:"quote_author,omitempty"`
 	QuoteMessage      string   `json:"quote_message,omitempty"`
+	EditTimestamp     *int64   `json:"edit_timestamp,omitempty"`
 }
 
 type signalSendResponse struct {
 	Timestamp string `json:"timestamp"`
+}
+
+type signalRemoteDeleteRequest struct {
+	Recipient string `json:"recipient"`
+	Timestamp int64  `json:"timestamp"`
 }
 
 type signalGroup struct {
@@ -171,8 +177,9 @@ func (b *Bsignal) JoinChannel(channel config.ChannelInfo) error {
 }
 
 func (b *Bsignal) Send(msg config.Message) (string, error) {
+	// Handle delete from other bridges
 	if msg.Event == config.EventMsgDelete {
-		return "", nil
+		return b.handleSendDelete(msg)
 	}
 
 	// Prepend username to message text since Signal has no webhook/impersonation
@@ -187,6 +194,14 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 		Message:    text,
 		Number:     b.number,
 		Recipients: []string{"group." + msg.Channel},
+	}
+
+	// Handle edit from other bridges — msg.ID is set when gateway finds existing message in cache
+	if msg.ID != "" {
+		if ts, err := strconv.ParseInt(msg.ID, 10, 64); err == nil {
+			req.EditTimestamp = &ts
+			b.Log.Debugf("Editing Signal message with timestamp %d", ts)
+		}
 	}
 
 	if msg.ParentID != "" {
@@ -244,6 +259,54 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 	var sendResp signalSendResponse
 	if err := json.Unmarshal(respBody, &sendResp); err == nil && sendResp.Timestamp != "" {
 		return sendResp.Timestamp, nil
+	}
+
+	return "", nil
+}
+
+func (b *Bsignal) handleSendDelete(msg config.Message) (string, error) {
+	if msg.ID == "" {
+		b.Log.Debug("Ignoring delete event with empty message ID")
+		return "", nil
+	}
+
+	ts, err := strconv.ParseInt(msg.ID, 10, 64)
+	if err != nil {
+		b.Log.Debugf("Ignoring delete event with non-numeric ID: %s", msg.ID)
+		return "", nil
+	}
+
+	b.Log.Debugf("=> Deleting Signal message with timestamp %d in group %s", ts, msg.Channel)
+
+	delReq := signalRemoteDeleteRequest{
+		Recipient: "group." + msg.Channel,
+		Timestamp: ts,
+	}
+
+	data, err := json.Marshal(delReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal delete request: %w", err)
+	}
+
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		fmt.Sprintf("%s/v1/remote-delete/%s", b.apiURL, b.number),
+		bytes.NewBuffer(data),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create delete request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("signal-cli delete returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	return "", nil

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -40,6 +40,7 @@ type signalEnvelope struct {
 	SourceName  string             `json:"sourceName"`
 	Timestamp   int64              `json:"timestamp"`
 	DataMessage *signalDataMessage `json:"dataMessage"`
+	EditMessage *signalEditMessage `json:"editMessage"`
 }
 
 type signalDataMessage struct {
@@ -49,6 +50,11 @@ type signalDataMessage struct {
 	Attachments  []signalAttachment  `json:"attachments"`
 	Quote        *signalQuote        `json:"quote"`
 	RemoteDelete *signalRemoteDelete `json:"remoteDelete"`
+}
+
+type signalEditMessage struct {
+	TargetSentTimestamp int64              `json:"targetSentTimestamp"`
+	DataMessage         signalDataMessage  `json:"dataMessage"`
 }
 
 type signalGroupInfo struct {
@@ -290,16 +296,22 @@ func (b *Bsignal) receiveMessages() {
 }
 
 func (b *Bsignal) handleMessage(msg signalMessage) {
+	if msg.Envelope.Source == b.number {
+		return
+	}
+
+	// Handle edit message
+	if msg.Envelope.EditMessage != nil {
+		b.handleEditMessage(msg)
+		return
+	}
+
 	dm := msg.Envelope.DataMessage
 	if dm == nil {
 		return
 	}
 
 	if dm.GroupInfo == nil {
-		return
-	}
-
-	if msg.Envelope.Source == b.number {
 		return
 	}
 
@@ -371,6 +383,41 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 	}
 
 	b.Remote <- rmsg
+}
+
+func (b *Bsignal) handleEditMessage(msg signalMessage) {
+	em := msg.Envelope.EditMessage
+	dm := &em.DataMessage
+
+	if dm.GroupInfo == nil {
+		return
+	}
+
+	channel, ok := b.groupMap[dm.GroupInfo.GroupID]
+	if !ok {
+		b.Log.Warnf("Unknown group internal_id: %s", dm.GroupInfo.GroupID)
+		return
+	}
+
+	if dm.Message == "" {
+		return
+	}
+
+	username := msg.Envelope.SourceName
+	if username == "" {
+		username = msg.Envelope.Source
+	}
+
+	// Use targetSentTimestamp as ID so gateway maps it to the original Discord message
+	b.Remote <- config.Message{
+		Username:  username,
+		Text:      dm.Message,
+		Channel:   channel,
+		Account:   b.Account,
+		Protocol:  "signal",
+		ID:        strconv.FormatInt(em.TargetSentTimestamp, 10),
+		Timestamp: time.UnixMilli(dm.Timestamp),
+	}
 }
 
 func (b *Bsignal) downloadAttachment(id string) (*[]byte, error) {

--- a/bridge/signal/signal.go
+++ b/bridge/signal/signal.go
@@ -2,10 +2,13 @@ package signal
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +29,8 @@ type Bsignal struct {
 	groupMap map[string]string
 }
 
+// signal-cli REST API receive types
+
 type signalMessage struct {
 	Envelope signalEnvelope `json:"envelope"`
 }
@@ -38,9 +43,12 @@ type signalEnvelope struct {
 }
 
 type signalDataMessage struct {
-	Message   string           `json:"message"`
-	Timestamp int64            `json:"timestamp"`
-	GroupInfo *signalGroupInfo `json:"groupInfo"`
+	Message      string              `json:"message"`
+	Timestamp    int64               `json:"timestamp"`
+	GroupInfo    *signalGroupInfo    `json:"groupInfo"`
+	Attachments  []signalAttachment  `json:"attachments"`
+	Quote        *signalQuote        `json:"quote"`
+	RemoteDelete *signalRemoteDelete `json:"remoteDelete"`
 }
 
 type signalGroupInfo struct {
@@ -48,10 +56,37 @@ type signalGroupInfo struct {
 	Type    string `json:"type"`
 }
 
+type signalAttachment struct {
+	ContentType string `json:"contentType"`
+	Filename    string `json:"filename"`
+	ID          string `json:"id"`
+	Size        int64  `json:"size"`
+}
+
+type signalQuote struct {
+	ID     int64  `json:"id"`
+	Author string `json:"author"`
+	Text   string `json:"text"`
+}
+
+type signalRemoteDelete struct {
+	Timestamp int64 `json:"timestamp"`
+}
+
+// signal-cli REST API send types
+
 type signalSendRequest struct {
-	Message    string   `json:"message"`
-	Number     string   `json:"number"`
-	Recipients []string `json:"recipients"`
+	Message           string   `json:"message"`
+	Number            string   `json:"number"`
+	Recipients        []string `json:"recipients"`
+	Base64Attachments []string `json:"base64_attachments,omitempty"`
+	QuoteTimestamp    *int64   `json:"quote_timestamp,omitempty"`
+	QuoteAuthor       string   `json:"quote_author,omitempty"`
+	QuoteMessage      string   `json:"quote_message,omitempty"`
+}
+
+type signalSendResponse struct {
+	Timestamp string `json:"timestamp"`
 }
 
 type signalGroup struct {
@@ -63,7 +98,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	return &Bsignal{
 		Config:    cfg,
 		fetchDone: make(chan bool),
-		client:    &http.Client{Timeout: 30 * time.Second},
+		client:    &http.Client{Timeout: 60 * time.Second},
 		groupMap:  make(map[string]string),
 	}
 }
@@ -95,8 +130,7 @@ func (b *Bsignal) Connect() error {
 		return fmt.Errorf("signal-cli API returned status %d", resp.StatusCode)
 	}
 
-	// Build group ID mapping: receive endpoint returns internal_id,
-	// but gateway config and send endpoint use id
+	// Build group ID mapping: receive returns internal_id, config and send use id
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read groups response: %w", err)
@@ -142,6 +176,40 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 		Recipients: []string{"group." + msg.Channel},
 	}
 
+	// Handle reply/quote from other bridges
+	if msg.ParentID != "" {
+		if ts, err := strconv.ParseInt(msg.ParentID, 10, 64); err == nil {
+			req.QuoteTimestamp = &ts
+		}
+	}
+
+	// Handle attachments from other bridges (e.g. Discord CDN URLs)
+	if files, ok := msg.Extra["file"]; ok {
+		for _, f := range files {
+			fi, ok := f.(config.FileInfo)
+			if !ok {
+				continue
+			}
+			var data []byte
+			if fi.Data != nil {
+				data = *fi.Data
+			} else if fi.URL != "" {
+				resp, err := b.client.Get(fi.URL)
+				if err != nil {
+					b.Log.Errorf("Failed to download attachment from %s: %s", fi.URL, err)
+					continue
+				}
+				data, _ = io.ReadAll(resp.Body)
+				resp.Body.Close()
+			}
+			if len(data) > 0 {
+				mime := mimeFromFilename(fi.Name)
+				b64 := fmt.Sprintf("data:%s;base64,%s", mime, base64.StdEncoding.EncodeToString(data))
+				req.Base64Attachments = append(req.Base64Attachments, b64)
+			}
+		}
+	}
+
 	data, err := json.Marshal(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal message: %w", err)
@@ -157,13 +225,21 @@ func (b *Bsignal) Send(msg config.Message) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("signal-cli API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Return signal timestamp as message ID for cross-protocol tracking
+	var sendResp signalSendResponse
+	if err := json.Unmarshal(respBody, &sendResp); err == nil && sendResp.Timestamp != "" {
+		return sendResp.Timestamp, nil
 	}
 
 	return "", nil
 }
+
+// WebSocket receive loop with automatic reconnection
 
 func (b *Bsignal) receiveLoop() {
 	for {
@@ -172,7 +248,6 @@ func (b *Bsignal) receiveLoop() {
 			return
 		default:
 			b.receiveMessages()
-			// Backoff before reconnecting
 			time.Sleep(3 * time.Second)
 		}
 	}
@@ -201,7 +276,7 @@ func (b *Bsignal) receiveMessages() {
 		_, rawMsg, err := conn.ReadMessage()
 		if err != nil {
 			b.Log.Errorf("WebSocket read error: %s", err)
-			return // Will reconnect via receiveLoop
+			return
 		}
 
 		var msg signalMessage
@@ -216,7 +291,7 @@ func (b *Bsignal) receiveMessages() {
 
 func (b *Bsignal) handleMessage(msg signalMessage) {
 	dm := msg.Envelope.DataMessage
-	if dm == nil || dm.Message == "" {
+	if dm == nil {
 		return
 	}
 
@@ -228,10 +303,26 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		return
 	}
 
-	// Map internal_id from receive to id used in gateway config
 	channel, ok := b.groupMap[dm.GroupInfo.GroupID]
 	if !ok {
 		b.Log.Warnf("Unknown group internal_id: %s", dm.GroupInfo.GroupID)
+		return
+	}
+
+	// Handle remote delete
+	if dm.RemoteDelete != nil {
+		b.Remote <- config.Message{
+			Event:    config.EventMsgDelete,
+			ID:       strconv.FormatInt(dm.RemoteDelete.Timestamp, 10),
+			Channel:  channel,
+			Account:  b.Account,
+			Protocol: "signal",
+		}
+		return
+	}
+
+	// Skip messages with no text and no attachments
+	if dm.Message == "" && len(dm.Attachments) == 0 {
 		return
 	}
 
@@ -240,12 +331,78 @@ func (b *Bsignal) handleMessage(msg signalMessage) {
 		username = msg.Envelope.Source
 	}
 
-	b.Remote <- config.Message{
+	rmsg := config.Message{
 		Username:  username,
 		Text:      dm.Message,
 		Channel:   channel,
 		Account:   b.Account,
 		Protocol:  "signal",
+		ID:        strconv.FormatInt(dm.Timestamp, 10),
 		Timestamp: time.UnixMilli(dm.Timestamp),
 	}
+
+	// Handle quote/reply
+	if dm.Quote != nil {
+		rmsg.ParentID = strconv.FormatInt(dm.Quote.ID, 10)
+	}
+
+	// Handle attachments
+	for _, att := range dm.Attachments {
+		data, err := b.downloadAttachment(att.ID)
+		if err != nil {
+			b.Log.Errorf("Failed to download attachment %s: %s", att.ID, err)
+			continue
+		}
+		fi := config.FileInfo{
+			Name:    att.Filename,
+			Data:    data,
+			Size:    att.Size,
+			Comment: dm.Message,
+		}
+		if rmsg.Extra == nil {
+			rmsg.Extra = make(map[string][]interface{})
+		}
+		rmsg.Extra["file"] = append(rmsg.Extra["file"], fi)
+	}
+
+	// When attachments carry the caption, clear text to avoid duplication
+	if len(dm.Attachments) > 0 && dm.Message != "" {
+		rmsg.Text = ""
+	}
+
+	b.Remote <- rmsg
+}
+
+func (b *Bsignal) downloadAttachment(id string) (*[]byte, error) {
+	resp, err := b.client.Get(fmt.Sprintf("%s/v1/attachments/%s", b.apiURL, id))
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("attachment endpoint returned %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read failed: %w", err)
+	}
+	return &data, nil
+}
+
+func mimeFromFilename(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	types := map[string]string{
+		".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+		".png": "image/png", ".gif": "image/gif",
+		".webp": "image/webp", ".svg": "image/svg+xml",
+		".mp4": "video/mp4", ".webm": "video/webm",
+		".mp3": "audio/mpeg", ".ogg": "audio/ogg",
+		".pdf": "application/pdf",
+	}
+	if mime, ok := types[ext]; ok {
+		return mime
+	}
+	return "application/octet-stream"
 }

--- a/gateway/bridgemap/bsignal.go
+++ b/gateway/bridgemap/bsignal.go
@@ -1,0 +1,12 @@
+//go:build !nosignal
+// +build !nosignal
+
+package bridgemap
+
+import (
+	bsignal "github.com/42wim/matterbridge/bridge/signal" //nolint:depguard
+)
+
+func init() { //nolint:gochecknoinits
+	FullMap["signal"] = bsignal.New
+}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -281,7 +281,7 @@ func (gw *Gateway) ignoreTextEmpty(msg *config.Message) bool {
 		return false
 	}
 	if msg.Event == config.EventMsgDelete {
-    return false
+		return false
 	}
 	// we have an attachment or actual bytes, do not ignore
 	if msg.Extra != nil &&

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -280,6 +280,9 @@ func (gw *Gateway) ignoreTextEmpty(msg *config.Message) bool {
 	if msg.Event == config.EventUserTyping {
 		return false
 	}
+	if msg.Event == config.EventMsgDelete {
+    return false
+	}
 	// we have an attachment or actual bytes, do not ignore
 	if msg.Extra != nil &&
 		(msg.Extra["attachments"] != nil ||


### PR DESCRIPTION
Description:
Adds native Signal protocol support to matterbridge via signal-cli REST API.

## Changes

### New: Signal bridge (`bridge/signal/signal.go`)
- Real-time message relay via WebSocket (signal-cli json-rpc mode)
- Text messages bidirectional: Signal ↔ Discord
- Attachments/images bidirectional (20MB size limit)
- Edit messages bidirectional
- Delete messages bidirectional
- Reply/quotes from Signal shown on Discord
- Username prefixed on Signal side since Signal has no webhook/impersonation
- 20MB attachment size limit to prevent OOM

### Modified: Gateway (`gateway/gateway.go`)
- Allow `EventMsgDelete` through `ignoreTextEmpty` filter (delete events have empty text)

### Modified: Dockerfile
- Switch runtime image from `distroless/static-debian11` to `debian:bullseye-slim`
- Add `ca-certificates` for TLS connectivity
- Required because CGO-enabled binary is dynamically linked

## Dependencies
- signal-cli REST API 0.97+ deployed as sidecar container
- Phone number registered and added to target Signal group

## Testing
Tested end-to-end with private Signal group ↔ Discord channel:
text, attachments, edit, delete, quotes all confirmed working both directions.

- https://github.com/status-im/infra-misc/issues/458