### PR TITLE
fix: resolve SQLite statement closed errors and waku lifecycle issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM golang:1.23-bullseye AS builder
 
-RUN apt update
-RUN apt install -y llvm clang
+RUN apt update && apt install -y llvm clang
 
-ADD go.mod go.sum ./
-RUN go mod download
+WORKDIR /build
+COPY . .
 
-COPY . /go/src/github.com/42wim/matterbridge
-
-WORKDIR /go/src/github.com/42wim/matterbridge
-
-ENV GOPATH=/go
+ENV GO111MODULE=on
 ENV CC=clang
 ENV CXX=clang++
 
@@ -19,5 +14,4 @@ RUN go build -ldflags=-checklinkname=0 -o /bin/matterbridge
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /bin/matterbridge /bin/matterbridge
-
 ENTRYPOINT ["/bin/matterbridge"]

--- a/bridge/status/status.go
+++ b/bridge/status/status.go
@@ -161,17 +161,26 @@ func (b *Bstatus) fetchMessagesLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			mResp, err := b.messenger.RetrieveAll()
-			if err != nil {
-				b.Log.WithError(err).Error("Failed to retrieve messages")
-				continue
-			}
-			for _, msg := range mResp.Messages() {
-				b.propagateMessage(msg)
-			}
+			b.fetchMessages()
 		case <-b.fetchDone:
 			return
 		}
+	}
+}
+
+func (b *Bstatus) fetchMessages() {
+	defer func() {
+		if r := recover(); r != nil {
+			b.Log.Errorf("Recovered from panic in RetrieveAll: %v", r)
+		}
+	}()
+	mResp, err := b.messenger.RetrieveAll()
+	if err != nil {
+		b.Log.WithError(err).Error("Failed to retrieve messages")
+		return
+	}
+	for _, msg := range mResp.Messages() {
+		b.propagateMessage(msg)
 	}
 }
 

--- a/bridge/status/status.go
+++ b/bridge/status/status.go
@@ -73,6 +73,7 @@ type Bstatus struct {
 	messenger  *status.Messenger
 
 	joinedCommunities []string
+	waku              *wakuv2.Waku
 }
 
 func New(cfg *bridge.Config) bridge.Bridger {
@@ -404,12 +405,7 @@ func (b *Bstatus) Connect() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to start waku")
 	}
-	defer func() {
-		err := waku.Stop()
-		if err != nil {
-			logger.Error("failed to stop waku", zap.Error(err))
-		}
-	}()
+	b.waku = waku
 
 	encryptionProtocol := encryption.New(
 		appDB,
@@ -516,6 +512,11 @@ func (b *Bstatus) Disconnect() error {
 	b.stopMessagesLoop()
 	if err := b.messenger.Shutdown(); err != nil {
 		return errors.Wrap(err, "Failed to stop Status messenger")
+	}
+	if b.waku != nil {
+		if err := b.waku.Stop(); err != nil {
+			b.Log.WithError(err).Error("Failed to stop waku")
+		}
 	}
 	if err := b.statusNode.Stop(); err != nil {
 		return errors.Wrap(err, "Failed to stop Status node")

--- a/vendor/github.com/status-im/status-go/services/communitytokens/service.go
+++ b/vendor/github.com/status-im/status-go/services/communitytokens/service.go
@@ -412,6 +412,9 @@ func (s *Service) DeploymentSignatureDigest(chainID uint64, addressFrom string, 
 }
 
 func (s *Service) ProcessCommunityTokenAction(message *protobuf.CommunityTokenAction) error {
+	if s.Messenger == nil {
+		return nil
+	}
 	communityToken, err := s.Messenger.GetCommunityTokenByChainAndAddress(int(message.ChainId), message.ContractAddress)
 	if err != nil {
 		return err


### PR DESCRIPTION
- fix(build): use Go module mode instead of GOPATH

Build was placing source in $GOPATH/src which causes Go to use
GOPATH mode and ignore go.mod. This can result in different
dependency resolution, causing sql: statement is closed errors
in status-go SQLite operations.

- fix(status): move waku lifecycle to struct to prevent premature shutdown

defer waku.Stop() in Connect() was closing waku when the function
returned successfully, causing 'sql: statement is closed' errors
when JoinChannel attempted to fetch communities.

Store waku as a struct field and stop it in Disconnect() instead.

- fix(status): add panic recovery and nil check for community token handler